### PR TITLE
fix(workflow): add timeout to prevent 6hr hangs

### DIFF
--- a/.github/workflows/supabase-security.yml
+++ b/.github/workflows/supabase-security.yml
@@ -40,6 +40,7 @@ jobs:
   security-audit:
     name: Supabase Security Audit & Auto-Fix
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       issues: write
@@ -81,6 +82,7 @@ jobs:
 
       - name: Run Autonomous Security Admin
         id: security_audit
+        timeout-minutes: 15
         run: |
           echo "🤖 Running autonomous security admin..."
           node scripts/supabase-admin-autonomous.mjs


### PR DESCRIPTION
## Summary
- Add 30min job timeout to security-audit job
- Add 15min step timeout to Run Autonomous Security Admin step

## Root Cause
The supabase-admin-autonomous.mjs script was hanging indefinitely.

## Test Plan
- Merge and wait for next scheduled run
- Verify workflow completes within 30min

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that caps runtime (30m job / 15m step) without altering security audit logic or production behavior.
> 
> **Overview**
> Adds **execution time limits** to the `Supabase Security Auto-Fix` GitHub Actions workflow so it can’t hang indefinitely.
> 
> The `security-audit` job now has a `30` minute timeout, and the `Run Autonomous Security Admin` step has a `15` minute timeout to bound the `supabase-admin-autonomous.mjs` run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38a1a4b07645762564e37cb8feadbadc745a8f14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->