### PR TITLE
fix: 0074 jest pre-commit env fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,8 @@ apps/website/server/openai.key
 # Env files (examples remain tracked)
 **/.env*
 !**/.env.example
+# Tracked Jest stubs (not secrets); see apps/website/.env.test
+!apps/website/.env.test
 
 # --- Custom: Build outputs ---
 # Monorepo-safe build ignores

--- a/apps/website/.env.test
+++ b/apps/website/.env.test
@@ -1,0 +1,5 @@
+# Stub values for Jest test environment only.
+# These are never used in production. They exist solely to satisfy
+# Next.js env validation during test startup.
+NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key-placeholder

--- a/apps/website/src/__tests__/SafeHTML.test.tsx
+++ b/apps/website/src/__tests__/SafeHTML.test.tsx
@@ -3,7 +3,7 @@
  */
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { SafeHTML } from '@strata-noble/ui';
+import { SafeHTML } from '@strata-noble/ui/SafeHTML';
 
 describe('SafeHTML (via @strata-noble/ui)', () => {
   it('should render safe HTML content', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ import nextJest from 'next/jest.js'
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files
-  dir: './',
+  dir: './apps/website',
 })
 
 // Add any custom config to be passed to Jest


### PR DESCRIPTION
Adds .env.test stubs and fixes jest.config.js dir path. Un-ignores apps/website/.env.test so stub env can be tracked. SafeHTML test imports @strata-noble/ui/SafeHTML to avoid pulling next/server via the package barrel (Request in jsdom). Pre-commit hook passes without --no-verify.

Made with [Cursor](https://cursor.com)