### PR TITLE
feat(site-revamp): OCS-SN-0011/0012 — nav IA + ThreeSurfaces homepage section

### DIFF
--- a/apps/website/src/app/(marketing)/page.tsx
+++ b/apps/website/src/app/(marketing)/page.tsx
@@ -2,7 +2,7 @@ import {
   MarketingHomeShell,
   HomepageHero,
   ProofBar,
-  TwoSurfaces,
+  ThreeSurfaces,
   HowItWorks,
   EcosystemProof,
   LeadLeakCheckSection,
@@ -45,7 +45,7 @@ export default function HomePage() {
       <main className="min-h-screen bg-[#070f1a]">
         <HomepageHero />
         <ProofBar />
-        <TwoSurfaces />
+        <ThreeSurfaces />
         <HowItWorks />
         <EcosystemProof />
         <LeadLeakCheckSection />

--- a/apps/website/src/components/homepage/ThreeSurfaces.tsx
+++ b/apps/website/src/components/homepage/ThreeSurfaces.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import Link from 'next/link';
+import { motion, useReducedMotion } from 'framer-motion';
+
+const surfaces = [
+  {
+    title: 'Consulting Services',
+    subtitle:
+      'Scoped engagements that install operational control systems. Lead Rescue starts at $997. Full pipeline buildout from $2,500.',
+    cta: 'View Services',
+    href: '/services',
+  },
+  {
+    title: 'Q SUITE',
+    subtitle:
+      'The operational control system your business runs on. Five modules — intake, client management, revenue intelligence, industry workflows, secure delivery. From $297/month.',
+    cta: 'Explore Platform',
+    href: '/q-suite',
+  },
+  {
+    title: 'ACHIEVERY',
+    subtitle:
+      'Track progress, build momentum, stay accountable. Goal tracking, daily execution, and progress insights. Free to start.',
+    cta: 'Try Free',
+    href: '/achievery',
+  },
+] as const;
+
+export function ThreeSurfaces() {
+  const prefersReduced = useReducedMotion();
+
+  const containerVariants = {
+    hidden: {},
+    visible: {
+      transition: { staggerChildren: prefersReduced ? 0 : 0.15 },
+    },
+  };
+
+  const cardVariants = {
+    hidden: { opacity: prefersReduced ? 1 : 0, y: prefersReduced ? 0 : 20 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: { duration: 0.55, ease: [0.25, 0.1, 0.25, 1] as const },
+    },
+  };
+
+  return (
+    <section className="relative overflow-hidden border-y border-slate-grey/20 bg-command-navy px-4 py-20">
+      <div className="pointer-events-none absolute inset-0 sn-ambient-grid opacity-40" aria-hidden />
+      <div className="mx-auto max-w-6xl">
+        <motion.div
+          initial={{ opacity: prefersReduced ? 1 : 0, y: prefersReduced ? 0 : 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-60px' }}
+          transition={{ duration: 0.5 }}
+          className="text-center"
+        >
+          <h2 className="text-2xl font-bold text-white md:text-3xl">
+            Consulting. Platform. Product. One firm.
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-slate-grey">
+            Three ways to work with Strata Noble — scoped engagements, platform licensing, and a standalone product.
+          </p>
+        </motion.div>
+
+        <motion.div
+          className="mx-auto mt-12 grid max-w-5xl gap-6 md:grid-cols-3"
+          variants={containerVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: '-60px' }}
+        >
+          {surfaces.map((card) => (
+            <motion.div
+              key={card.title}
+              variants={cardVariants}
+              whileHover={prefersReduced ? {} : { y: -3 }}
+              transition={{ type: 'spring', stiffness: 300, damping: 24 }}
+              className="sn-surface sn-surface-hover group flex flex-col rounded-sm p-8"
+            >
+              <h3 className="text-xl font-semibold text-white transition-colors duration-300 group-hover:text-field-sage">
+                {card.title}
+              </h3>
+              <p className="mt-3 flex-grow text-sm leading-relaxed text-slate-grey">
+                {card.subtitle}
+              </p>
+              <Link
+                href={card.href}
+                className="mt-8 inline-flex items-center gap-1 text-sm font-semibold text-field-sage"
+              >
+                {card.cta}
+                <span
+                  className="transition-transform duration-200 group-hover:translate-x-1"
+                  aria-hidden
+                >
+                  →
+                </span>
+              </Link>
+            </motion.div>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/homepage/index.ts
+++ b/apps/website/src/components/homepage/index.ts
@@ -2,6 +2,7 @@ export { MarketingHomeShell } from './MarketingHomeShell';
 export { HomepageHero } from './HomepageHero';
 export { ProofBar } from './ProofBar';
 export { TwoSurfaces } from './TwoSurfaces';
+export { ThreeSurfaces } from './ThreeSurfaces';
 export { HowItWorks } from './HowItWorks';
 export { EcosystemProof } from './EcosystemProof';
 export { HomepageCTA } from './HomepageCTA';

--- a/apps/website/src/components/site/SiteNav.tsx
+++ b/apps/website/src/components/site/SiteNav.tsx
@@ -9,15 +9,16 @@ import Link from 'next/link'
 import { Logo } from '../Logo'
 
 /**
- * Primary IA: Home | Services | How It Works | Proof | About | Contact
+ * Primary IA: Home | Services | Q SUITE | ACHIEVERY | About | Proof | Contact
  */
 
 const navigation = [
   { name: 'Home', href: '/', description: 'Strata Noble' },
-  { name: 'Services', href: '/services', description: 'What we build and install' },
-  { name: 'How It Works', href: '/how-it-works', description: 'Our process' },
-  { name: 'Proof', href: '/proof', description: 'What we have shipped' },
+  { name: 'Services', href: '/services', description: 'Consulting engagements' },
+  { name: 'Q SUITE', href: '/q-suite', description: 'The operational control system' },
+  { name: 'ACHIEVERY', href: '/achievery', description: 'Goals and accountability' },
   { name: 'About', href: '/about', description: 'Who we are' },
+  { name: 'Proof', href: '/proof', description: 'Case studies and ecosystem' },
   { name: 'Contact', href: '/contact', description: 'Get in touch' },
 ]
 


### PR DESCRIPTION
## Summary

- **OCS-SN-0011 (Nav + IA):** Updated `SiteNav` primary IA from `Home | Services | How It Works | Proof | About | Contact` to `Home | Services | Q SUITE | ACHIEVERY | About | Proof | Contact`. All target routes already existed (`/q-suite`, `/achievery`, `/proof`, `/services`).
- **OCS-SN-0012 (Homepage surfaces):** Created `ThreeSurfaces` component replacing `TwoSurfaces`. Now shows all three revenue surfaces with pricing anchors: Consulting ($997+), Q SUITE ($297/mo), ACHIEVERY (free). Updated `homepage/index.ts` export and `page.tsx` to use the new component.

## What was already done (no action needed)
- Footer: correct 4-column structure (Services | Platform | Company | Legal) ✅
- SmartConsultingBar: "Free Lead Diagnostic" → `/contact?service=lead-rescue` ✅
- All target routes present and fully built (not stubs) ✅
- OCS-SN-0010 (offerings.ts reconciliation): landed in prior PRs ✅

## Test plan
- [ ] Nav renders: Services, Q SUITE, ACHIEVERY, About, Proof, Contact on desktop
- [ ] Mobile hamburger shows all 7 nav items
- [ ] Homepage section 2 shows three cards: Consulting, Q SUITE, ACHIEVERY — each with pricing and CTA
- [ ] Q SUITE card links to `/q-suite`, ACHIEVERY to `/achievery`, Consulting to `/services`
- [ ] `npm run build` passes ✅ (verified pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)