### PR TITLE
fix(ci): skip Supabase CLI install if already present on runner

### DIFF
--- a/.github/workflows/integration-stress-test.yml
+++ b/.github/workflows/integration-stress-test.yml
@@ -51,8 +51,12 @@ jobs:
 
     - name: Install Supabase CLI
       run: |
-        curl -sSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz | tar -xz
-        sudo mv supabase /usr/local/bin/
+        if ! command -v supabase &> /dev/null; then
+          curl -sSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz | tar -xz
+          sudo mv supabase /usr/local/bin/
+        else
+          echo "Supabase CLI already installed: $(supabase --version)"
+        fi
 
     - name: Hard reset Supabase (clean state)
       run: |


### PR DESCRIPTION
Rebased fix from PR #48. Guards install with command -v check — ubuntu-latest runners now ship Supabase CLI pre-installed. Fixes Integration Stress Test. PLATOPS-SN-GHA-DEPENDABOT-0082 t-002.