### PR TITLE
fix(ci): skip E2E job cleanly when Supabase secrets are absent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,44 +65,12 @@ jobs:
         with:
           directory: apps/platform/coverage
   
-  e2e:
-    runs-on: ubuntu-latest
-    needs: ci
-    if: github.event_name == 'pull_request'
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20.x'
-          cache: 'npm'
-      
-      - name: Install dependencies
-        run: |
-          npm ci
-          cd apps/platform && npm ci
-          cd packages/ui && npm ci
-          cd packages/utils && npm ci --legacy-peer-deps
-      
-      - name: Install Playwright
-        run: cd apps/platform && npm run e2e:install
-      
-      - name: Run E2E tests
-        run: cd apps/platform && npm run e2e
-        env:
-          CI: true
-      
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: playwright-results
-          path: apps/platform/playwright-report/
-          retention-days: 7
-  
+  # The standalone `e2e` job that previously lived here was a duplicate of the
+  # dedicated `.github/workflows/e2e.yml` workflow, but with no Supabase env
+  # configuration — so it always failed on `npm run e2e` against an unreachable
+  # backend. Removed in favor of the single `e2e` workflow, which gates itself
+  # on E2E_SUPABASE_URL being present (see apps/platform/E2E_SEED_SETUP.md).
+
   security:
     runs-on: ubuntu-latest
     needs: ci

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,10 +7,23 @@ on:
 jobs:
   test-e2e:
     runs-on: ubuntu-latest
+    # Lift secret to job-level env so subsequent step `if:` expressions can read it.
+    # GitHub does not expose `secrets.*` to step `if:` directly, so this indirection
+    # is required to gate steps on whether the E2E Supabase project has been
+    # provisioned (see apps/platform/E2E_SEED_SETUP.md).
+    env:
+      E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
     steps:
+      - name: Skip notice (E2E secrets not configured)
+        if: env.E2E_SUPABASE_URL == ''
+        run: |
+          echo "::warning::E2E_SUPABASE_URL not configured — skipping E2E suite. Configure GitHub Actions secrets per apps/platform/E2E_SEED_SETUP.md to enable."
+
       - uses: actions/checkout@v6
+        if: env.E2E_SUPABASE_URL != ''
 
       - name: Use Node.js 20.x
+        if: env.E2E_SUPABASE_URL != ''
         uses: actions/setup-node@v6
         with:
           node-version: 20.x
@@ -20,14 +33,17 @@ jobs:
             apps/platform/package-lock.json
 
       - name: Install platform dependencies
+        if: env.E2E_SUPABASE_URL != ''
         working-directory: apps/platform
         run: npm ci --legacy-peer-deps
 
       - name: Install Playwright browsers
+        if: env.E2E_SUPABASE_URL != ''
         working-directory: apps/platform
         run: npx playwright install --with-deps
 
       - name: Seed E2E test users
+        if: env.E2E_SUPABASE_URL != ''
         working-directory: apps/platform
         run: npm run seed:e2e
         env:
@@ -39,6 +55,7 @@ jobs:
           E2E_INCOMPLETE_PASSWORD: ${{ secrets.E2E_INCOMPLETE_PASSWORD }}
 
       - name: Run E2E smoke test
+        if: env.E2E_SUPABASE_URL != ''
         working-directory: apps/platform
         run: npm run e2e
         env:

--- a/apps/platform/scripts/seed-e2e.ts
+++ b/apps/platform/scripts/seed-e2e.ts
@@ -17,8 +17,19 @@ const INCOMPLETE_EMAIL = process.env.E2E_INCOMPLETE_EMAIL || "e2e.incomplete@ach
 const INCOMPLETE_PASSWORD = process.env.E2E_INCOMPLETE_PASSWORD || "ChangeMe-Incomplete-123!";
 
 // SAFETY CHECKS
+// In CI, missing secrets are not a hard failure: we want PRs from forks (or branches
+// where the E2E Supabase project has not been provisioned yet) to surface a clear
+// warning and skip cleanly rather than fail the whole workflow. The dedicated e2e
+// workflow also guards the Playwright run on the same env var, so skipping here
+// produces a no-op job that the merge button can ignore.
+// To run the seeder locally, populate apps/platform/.env.e2e (see E2E_SEED_SETUP.md).
 if (!URL || !SERVICE_KEY) {
-  throw new Error("Missing E2E_SUPABASE_URL or E2E_SUPABASE_SERVICE_ROLE_KEY");
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[seed-e2e] Skipping: E2E_SUPABASE_URL or E2E_SUPABASE_SERVICE_ROLE_KEY not set. " +
+      "If this is CI, configure GitHub Actions secrets per apps/platform/E2E_SEED_SETUP.md.",
+  );
+  process.exit(0);
 }
 
 // CRITICAL: Prevent running against production


### PR DESCRIPTION
## Why

The dedicated `e2e` workflow has been failing on **every PR for 10+ days**: dependabot, fix branches, feature branches, in-flight site work — all shipping with a red required-looking check. Root cause: the repo never had `E2E_SUPABASE_URL` / `E2E_SUPABASE_SERVICE_ROLE_KEY` (or the 5 supporting secrets) configured in GitHub Actions, so `seed-e2e.ts` throws on startup.

There was also a **second, even more broken** `e2e` job duplicated inside `ci.yml` that didn't pass any Supabase env at all.

This PR makes the workflow honest about that state without lying that E2E is passing. It does NOT enable the suite — it lets the workflow skip cleanly until secrets are provisioned.

## What

1. **`apps/platform/scripts/seed-e2e.ts`** — when secrets are missing, warn + `process.exit(0)` instead of throwing. Local runs and CI runs *with* secrets configured behave exactly as before.

2. **`.github/workflows/e2e.yml`** — lift `E2E_SUPABASE_URL` to job-level env (so step `if:` expressions can read it; GitHub doesn't expose `secrets.*` to step `if:` directly), and gate every meaningful step on it. When secrets are absent the job emits a `::warning::` and ends green; when secrets are present, behaviour is identical to before.

3. **`.github/workflows/ci.yml`** — delete the duplicate `e2e` job (the one with no env wiring). Single source of truth is now `e2e.yml`.

## Stat

```
.github/workflows/ci.yml          | 44 +++--------------------
.github/workflows/e2e.yml         | 17 +++++++++
apps/platform/scripts/seed-e2e.ts | 13 ++++++-
3 files changed, 35 insertions(+), 39 deletions(-)
```

## How to enable E2E for real (follow-up work, not this PR)

Provision a separate `stratanoble-e2e` Supabase project per `apps/platform/E2E_SEED_SETUP.md` and populate these 7 GitHub Actions secrets:

- `E2E_SUPABASE_URL`
- `E2E_SUPABASE_SERVICE_ROLE_KEY`
- `E2E_COMPLETED_EMAIL`, `E2E_COMPLETED_PASSWORD`
- `E2E_INCOMPLETE_EMAIL`, `E2E_INCOMPLETE_PASSWORD`
- `E2E_APP_BASE_URL`

Once the secrets land, the existing workflow will start running real E2E with no further code change.

## Test plan

- [x] `npm run validate` (lint + typecheck + tests + build + contracts + brand) passes locally
- [ ] On this PR: the `e2e` workflow's `test-e2e` job ends green with a `::warning::` annotation explaining secrets are missing
- [ ] On this PR: `ci.yml` no longer reports a separate failing `e2e` job
- [ ] The 7 other checks (`ci (20.x)`, `proofloop`, `audit`, `security`, Netlify previews) keep passing

## Unblocks

PR #59 (`OCS-SN-0011/0012` — nav IA + ThreeSurfaces) and every other open PR currently sitting on red E2E.

## Out of scope (flagged for later)

- Pre-existing secret-scan findings (7 errors + 7 warnings in `main`, including a service-role-key committed to the `feature/site-revamp-phase-1a` branch history). Should be tracked as a separate security item.
- Pipeline Buildout pricing drift in `apps/website/src/data/offerings.ts` ($2,500 in code vs $4,997 in `SN-OFFER-ARCHITECTURE.md` v2.1.0). Awaiting confirmation from Steve before patching.
