### PR TITLE
feat(intake): add Q SUITE demo + ACHIEVERY early-access forms on offer pages

### DIFF
--- a/apps/website/src/app/(marketing)/achievery/page.tsx
+++ b/apps/website/src/app/(marketing)/achievery/page.tsx
@@ -1,5 +1,10 @@
 import { Metadata } from 'next';
-import { AchieveryHero, AchieveryPricing, AchieveryIAP } from '@/components/achievery-marketing';
+import {
+  AchieveryHero,
+  AchieveryPricing,
+  AchieveryIAP,
+  AchieveryEarlyAccessEmbed,
+} from '@/components/achievery-marketing';
 
 export const metadata: Metadata = {
   title: 'ACHIEVERY | Strata Noble',
@@ -21,6 +26,7 @@ export default function AchieveryMarketingPage() {
       </section>
       <AchieveryPricing />
       <AchieveryIAP />
+      <AchieveryEarlyAccessEmbed />
     </>
   );
 }

--- a/apps/website/src/app/(marketing)/q-suite/page.tsx
+++ b/apps/website/src/app/(marketing)/q-suite/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { QSuiteHero, ModuleShowcase, QSuitePricing } from '@/components/q-suite';
+import { QSuiteHero, ModuleShowcase, QSuitePricing, QSuiteDemoForm } from '@/components/q-suite';
 
 export const metadata: Metadata = {
   title: 'Q SUITE | Strata Noble',
@@ -32,6 +32,7 @@ export default function QSuitePage() {
           </div>
         </div>
       </section>
+      <QSuiteDemoForm />
       <section className="bg-white px-4 py-12">
         <div className="mx-auto flex max-w-3xl flex-col items-center justify-center gap-4 text-center text-sm text-slate-600 sm:flex-row">
           <Link href="/services" className="font-semibold text-forest-green hover:underline">

--- a/apps/website/src/components/achievery-marketing/AchieveryEarlyAccessEmbed.tsx
+++ b/apps/website/src/components/achievery-marketing/AchieveryEarlyAccessEmbed.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useState } from 'react';
+
+type Status = 'idle' | 'loading' | 'success' | 'error' | 'duplicate';
+
+export function AchieveryEarlyAccessEmbed() {
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    goals: '',
+  });
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('loading');
+    setErrorMessage('');
+
+    try {
+      const res = await fetch('/api/email/early-access', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: formData.name.trim(),
+          email: formData.email.trim(),
+          // /api/email/early-access accepts an optional `role` field; we don't
+          // collect it on this embed (kept short) — `goals` is enough signal.
+          goals: formData.goals.trim() || undefined,
+        }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        throw new Error(data?.error || data?.message || 'Submission failed');
+      }
+
+      // /api/email/early-access returns success with `data.alreadySignedUp = true`
+      // when the email is already on the list — surface that distinctly so the
+      // user doesn't think they need to retry.
+      if (data?.data?.alreadySignedUp) {
+        setStatus('duplicate');
+      } else {
+        setStatus('success');
+      }
+
+      if (typeof window !== 'undefined' && (window as unknown as { gtag?: (...a: unknown[]) => void }).gtag) {
+        (window as unknown as { gtag: (...a: unknown[]) => void }).gtag(
+          'event',
+          'form_submit_success_achievery_early_access',
+        );
+      }
+
+      setFormData({ name: '', email: '', goals: '' });
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Something went wrong');
+
+      if (typeof window !== 'undefined' && (window as unknown as { gtag?: (...a: unknown[]) => void }).gtag) {
+        (window as unknown as { gtag: (...a: unknown[]) => void }).gtag(
+          'event',
+          'form_submit_error_achievery_early_access',
+        );
+      }
+    }
+  };
+
+  return (
+    <section
+      id="achievery-early-access"
+      className="bg-gradient-to-br from-field-sage/10 via-white to-navy-50 px-4 py-16 md:py-20"
+    >
+      <div className="mx-auto max-w-2xl">
+        <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg md:p-10">
+          <div className="text-center">
+            <p className="text-xs font-semibold uppercase tracking-widest text-forest-green">
+              Early access
+            </p>
+            <h2 className="mt-3 text-2xl font-bold text-command-navy md:text-3xl">
+              Get notified when ACHIEVERY opens up
+            </h2>
+            <p className="mt-3 text-sm text-slate-600 md:text-base">
+              Free to join. We&apos;ll email you the moment your account is ready &mdash;
+              no marketing drip, no sales calls.
+            </p>
+          </div>
+
+          {status === 'success' || status === 'duplicate' ? (
+            <div
+              role="status"
+              className="mt-8 rounded-2xl border border-forest-green/30 bg-field-sage/10 p-6 text-center"
+            >
+              <div className="text-4xl text-forest-green" aria-hidden="true">
+                ✓
+              </div>
+              <h3 className="mt-3 text-xl font-semibold text-command-navy">
+                {status === 'duplicate'
+                  ? "You're already on the list."
+                  : "You're on the list."}
+              </h3>
+              <p className="mt-2 text-sm text-slate-600">
+                {status === 'duplicate'
+                  ? "No problem — we have your email and we'll be in touch when access opens."
+                  : "We'll email you the moment access opens. Check your inbox for a confirmation."}
+              </p>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="mt-8 grid gap-5">
+              <div>
+                <label
+                  htmlFor="ach-name"
+                  className="mb-1 block text-sm font-semibold text-command-navy"
+                >
+                  Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="ach-name"
+                  name="name"
+                  type="text"
+                  required
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-command-navy focus:border-forest-green focus:outline-none focus:ring-2 focus:ring-forest-green/30"
+                  disabled={status === 'loading'}
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="ach-email"
+                  className="mb-1 block text-sm font-semibold text-command-navy"
+                >
+                  Email <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="ach-email"
+                  name="email"
+                  type="email"
+                  required
+                  value={formData.email}
+                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-command-navy focus:border-forest-green focus:outline-none focus:ring-2 focus:ring-forest-green/30"
+                  disabled={status === 'loading'}
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="ach-goals"
+                  className="mb-1 block text-sm font-semibold text-command-navy"
+                >
+                  What do you want ACHIEVERY to help you do?{' '}
+                  <span className="text-slate-400">(optional)</span>
+                </label>
+                <textarea
+                  id="ach-goals"
+                  name="goals"
+                  rows={3}
+                  value={formData.goals}
+                  onChange={(e) => setFormData({ ...formData, goals: e.target.value })}
+                  placeholder="e.g. Track daily sales activity, stop losing weeks to vague goals."
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-command-navy focus:border-forest-green focus:outline-none focus:ring-2 focus:ring-forest-green/30"
+                  disabled={status === 'loading'}
+                />
+              </div>
+
+              {status === 'error' && (
+                <div
+                  role="alert"
+                  className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+                >
+                  {errorMessage || 'Something went wrong. Please try again.'}
+                </div>
+              )}
+
+              <button
+                type="submit"
+                disabled={status === 'loading'}
+                className="inline-flex w-full items-center justify-center rounded-lg bg-forest-green px-6 py-3 text-sm font-semibold text-white transition hover:bg-forest-green/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {status === 'loading' ? 'Joining…' : 'Join the early access list'}
+              </button>
+
+              <p className="text-center text-xs text-slate-500">
+                We&apos;ll never share your information. Unsubscribe at any time.
+              </p>
+            </form>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/achievery-marketing/index.ts
+++ b/apps/website/src/components/achievery-marketing/index.ts
@@ -1,3 +1,4 @@
 export { AchieveryHero } from './AchieveryHero';
 export { AchieveryPricing } from './AchieveryPricing';
 export { AchieveryIAP } from './AchieveryIAP';
+export { AchieveryEarlyAccessEmbed } from './AchieveryEarlyAccessEmbed';

--- a/apps/website/src/components/q-suite/QSuiteDemoForm.tsx
+++ b/apps/website/src/components/q-suite/QSuiteDemoForm.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useState } from 'react';
+import { withCsrfHeaders } from '@/lib/csrf-client';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+const MIN_MESSAGE_LENGTH = 10;
+
+export function QSuiteDemoForm() {
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    businessName: '',
+    message: '',
+  });
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('loading');
+    setErrorMessage('');
+
+    // /api/contact's ContactFormSchema does not have a businessName field, so
+    // fold it into the message body to preserve context for the sales team
+    // without requiring a schema migration.
+    const composedMessage = formData.businessName
+      ? `Business: ${formData.businessName.trim()}\n\n${formData.message.trim()}`
+      : formData.message.trim();
+
+    try {
+      const init = await withCsrfHeaders({
+        method: 'POST',
+        body: JSON.stringify({
+          name: formData.name.trim(),
+          email: formData.email.trim(),
+          topic: 'qsuite-demo',
+          source: 'qsuite-page',
+          message: composedMessage,
+        }),
+      });
+
+      const res = await fetch('/api/contact', init);
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data?.error || data?.message || 'Submission failed. Please try again.',
+        );
+      }
+
+      setStatus('success');
+
+      if (typeof window !== 'undefined' && (window as unknown as { gtag?: (...a: unknown[]) => void }).gtag) {
+        (window as unknown as { gtag: (...a: unknown[]) => void }).gtag(
+          'event',
+          'form_submit_success_qsuite_demo',
+        );
+      }
+
+      setFormData({ name: '', email: '', businessName: '', message: '' });
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Something went wrong');
+
+      if (typeof window !== 'undefined' && (window as unknown as { gtag?: (...a: unknown[]) => void }).gtag) {
+        (window as unknown as { gtag: (...a: unknown[]) => void }).gtag(
+          'event',
+          'form_submit_error_qsuite_demo',
+        );
+      }
+    }
+  };
+
+  return (
+    <section
+      id="qsuite-demo"
+      className="border-t border-slate-200 bg-slate-50 px-4 py-16 md:py-20"
+    >
+      <div className="mx-auto max-w-3xl">
+        <div className="text-center md:text-left">
+          <h2 className="text-2xl font-bold text-command-navy md:text-3xl">
+            Request a Q SUITE walkthrough
+          </h2>
+          <p className="mt-3 max-w-2xl text-slate-600">
+            Tell us what your business does and where it leaks. We&apos;ll set up a 30-minute
+            walkthrough of the modules that map to your workflow &mdash; no slide decks,
+            real screens.
+          </p>
+        </div>
+
+        {status === 'success' ? (
+          <div
+            role="status"
+            className="mt-8 rounded-2xl border border-forest-green/30 bg-field-sage/10 p-8 text-center"
+          >
+            <div className="text-4xl text-forest-green" aria-hidden="true">
+              ✓
+            </div>
+            <h3 className="mt-3 text-xl font-semibold text-command-navy">
+              Request received.
+            </h3>
+            <p className="mt-2 text-sm text-slate-600">
+              We&apos;ll reach out within one business day to schedule the walkthrough.
+            </p>
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="mt-8 grid gap-5 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:p-8"
+          >
+            <div className="grid gap-5 md:grid-cols-2">
+              <div>
+                <label
+                  htmlFor="qs-name"
+                  className="mb-1 block text-sm font-semibold text-command-navy"
+                >
+                  Your name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="qs-name"
+                  name="name"
+                  type="text"
+                  required
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-command-navy focus:border-forest-green focus:outline-none focus:ring-2 focus:ring-forest-green/30"
+                  disabled={status === 'loading'}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="qs-email"
+                  className="mb-1 block text-sm font-semibold text-command-navy"
+                >
+                  Work email <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="qs-email"
+                  name="email"
+                  type="email"
+                  required
+                  value={formData.email}
+                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-command-navy focus:border-forest-green focus:outline-none focus:ring-2 focus:ring-forest-green/30"
+                  disabled={status === 'loading'}
+                />
+              </div>
+            </div>
+
+            <div>
+              <label
+                htmlFor="qs-business"
+                className="mb-1 block text-sm font-semibold text-command-navy"
+              >
+                Business name <span className="text-slate-400">(optional)</span>
+              </label>
+              <input
+                id="qs-business"
+                name="businessName"
+                type="text"
+                value={formData.businessName}
+                onChange={(e) =>
+                  setFormData({ ...formData, businessName: e.target.value })
+                }
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-command-navy focus:border-forest-green focus:outline-none focus:ring-2 focus:ring-forest-green/30"
+                disabled={status === 'loading'}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="qs-message"
+                className="mb-1 block text-sm font-semibold text-command-navy"
+              >
+                What are you trying to fix? <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                id="qs-message"
+                name="message"
+                required
+                minLength={MIN_MESSAGE_LENGTH}
+                rows={4}
+                value={formData.message}
+                onChange={(e) => setFormData({ ...formData, message: e.target.value })}
+                placeholder="e.g. Leads are coming in but follow-up is dropping. We want CRM + booking + SMS to actually talk to each other."
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-command-navy focus:border-forest-green focus:outline-none focus:ring-2 focus:ring-forest-green/30"
+                disabled={status === 'loading'}
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Two or three sentences is enough. The more concrete, the better the demo.
+              </p>
+            </div>
+
+            {status === 'error' && (
+              <div
+                role="alert"
+                className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+              >
+                {errorMessage || 'Something went wrong. Please try again.'}
+              </div>
+            )}
+
+            <div className="flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-slate-500">
+                We&apos;ll respond within one business day. No automated drip sequences.
+              </p>
+              <button
+                type="submit"
+                disabled={status === 'loading'}
+                className="inline-flex items-center justify-center rounded-lg bg-command-navy px-6 py-3 text-sm font-semibold text-white transition hover:bg-command-navy/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {status === 'loading' ? 'Sending…' : 'Request walkthrough'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/website/src/components/q-suite/index.ts
+++ b/apps/website/src/components/q-suite/index.ts
@@ -1,3 +1,4 @@
 export { QSuiteHero } from './QSuiteHero';
 export { ModuleShowcase } from './ModuleShowcase';
 export { QSuitePricing } from './QSuitePricing';
+export { QSuiteDemoForm } from './QSuiteDemoForm';


### PR DESCRIPTION
## Why

Per audit of `OCS-SN-SITE-REVAMP-0086`, the `/services`, `/q-suite`, and `/achievery` pages already existed and rendered real content (not stubs). But two of the three offer surfaces had **no in-page lead capture** — visitors had to navigate to `/contact`, `/achievery-early-access`, or just bounce. That's the actual revenue gap, not page existence.

This PR closes the gap with the smallest possible change: **no new API routes, no schema migrations, no new dependencies.** Both forms reuse production endpoints that already write to Supabase.

## What

1. **`components/q-suite/QSuiteDemoForm.tsx`** (new, 197 lines) — client component that posts to `/api/contact` with `topic='qsuite-demo'`, `source='qsuite-page'`. Uses `withCsrfHeaders` since `/api/contact` is CSRF-protected. Optional `businessName` field is folded into the message body to fit `ContactFormSchema` without changes.

2. **`components/achievery-marketing/AchieveryEarlyAccessEmbed.tsx`** (new, 184 lines) — client component that posts to `/api/email/early-access`. Honestly distinguishes the "already signed up" response from a fresh submission so users get an accurate message instead of a spurious success.

3. Both components rendered on their respective marketing pages:
   - `/q-suite` — between the "Industry proof" panel and the cross-link footer.
   - `/achievery` — after `AchieveryIAP` (final section before footer).

4. Both use the existing `command-navy` / `forest-green` / `field-sage` design tokens to match each surface's visual language. ACHIEVERY embed leans on the gradient background pattern from the existing `/achievery-early-access` standalone page; Q SUITE form uses the slate/white palette consistent with `QSuitePricing`.

5. Analytics events emitted on success/error (`form_submit_success_qsuite_demo`, `form_submit_success_achievery_early_access`, etc.) using the same gtag pattern as `LeadRescueForm`.

## Stat

```
6 files changed, 428 insertions(+), 2 deletions(-)
+++ apps/website/src/components/q-suite/QSuiteDemoForm.tsx                     (new)
+++ apps/website/src/components/achievery-marketing/AchieveryEarlyAccessEmbed.tsx (new)
M   apps/website/src/components/q-suite/index.ts                                (+1)
M   apps/website/src/components/achievery-marketing/index.ts                    (+1)
M   apps/website/src/app/(marketing)/q-suite/page.tsx                           (+1)
M   apps/website/src/app/(marketing)/achievery/page.tsx                         (+5/-1)
```

## Test plan

- [x] `npm run validate` (lint + typecheck + tests + production build + contracts + brand) passes locally — see commit history (157s build, all checks ✅)
- [x] My new files produce **0 ESLint warnings** (verified)
- [ ] Smoke: visit `/q-suite` on Netlify deploy preview, scroll to the new "Request a Q SUITE walkthrough" section, submit a test entry, confirm a `contact_submissions` row appears in Supabase with `topic='qsuite-demo'`
- [ ] Smoke: visit `/achievery`, scroll to the new "Get notified when ACHIEVERY opens up" section, submit a test entry, confirm an `early_access_signups` row appears in Supabase with `metadata.form_version='achievery-early-access-v1'`
- [ ] Smoke: re-submit the ACHIEVERY form with the same email, confirm the "You're already on the list" branch fires (not a spurious success)
- [ ] Smoke: try the Q SUITE form with a < 10 char message, confirm the API returns the validator error and the form shows it cleanly

## Out of scope (deferred — flagged for follow-up work items)

- **Pipeline Buildout pricing drift:** `data/offerings.ts` has Pipeline Buildout at `$2,500` but `SN-OFFER-ARCHITECTURE.md` v2.1.0 mandates `$4,997 (project)`. This is a hard-limit-#8 violation already shipped to production. Awaiting confirmation from Steve before patching public pricing.
- **Source-tag bug:** `apps/website/src/app/api/intake/pipeline-buildout/route.ts` hard-codes `source: 'PHASE_3'`. The label is undocumented and inconsistent with the sibling `LEAD_RESCUE` source on `/api/intake/lead-rescue`. Should be `'PIPELINE_BUILDOUT'`. Two-line fix; tracking separately.
- **CSRF re-enablement:** `/api/email/early-access` has CSRF disabled with a "temporarily disabled for development" comment that is currently in production. This PR uses the route as-is.
- **Storage consolidation:** Lead capture currently writes to 5 different Supabase tables via 3 different access patterns (Prisma, `db.*` helper, direct `@supabase/supabase-js`). Sales team needs a unified view. Real refactor with migration risk — separate work item.

## Unblocks

The P0 revenue campaign now has in-page conversion paths on both Q SUITE and ACHIEVERY surfaces, alongside the consulting CTAs already on `/services`.
