### PR TITLE
fix(ci): pin Supabase CLI to 2.90.0 — resolve gotrue manifest unknown (0094)

### DIFF
--- a/.github/workflows/integration-stress-test.yml
+++ b/.github/workflows/integration-stress-test.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install Supabase CLI
       uses: supabase/setup-cli@v1
       with:
-        version: latest
+        version: 2.90.0
 
     - name: Hard reset Supabase (clean state)
       run: |


### PR DESCRIPTION
## Summary

- Pins `supabase/setup-cli@v1` from `version: latest` to `version: 2.90.0`
- `version: latest` was resolving to a CLI build referencing `ghcr.io/supabase/gotrue:v2.184.1` — an image tag that does not exist on GHCR
- CLI 2.90.0 bundles `supabase/gotrue:v2.188.1` from Docker Hub, which resolves the pull failure

## Root cause

Confirmed via run logs (run ID 24648888260). Four consecutive Monday runs (Mar 30 – Apr 20) failed at `supabase start`:
```
failed to pull docker image: Error response from daemon: manifest unknown
Retrying: ghcr.io/supabase/gotrue:v2.184.1
```
Upstream: supabase/cli#4690, supabase/cli#4696 (open as of 2026-04-20).

## Test plan
- [ ] Merge and trigger manually: `gh workflow run integration-stress-test.yml`
- [ ] Confirm `supabase start` clears the Docker pull step

🤖 Generated with [Claude Code](https://claude.ai/claude-code)