### PR TITLE
fix(ci): bump Supabase CLI 2.93.0 -> 2.95.4 [QUICKFIX-SN-INTEGRATION-STRESS-TEST-0094]

### DIFF
--- a/.github/workflows/integration-stress-test.yml
+++ b/.github/workflows/integration-stress-test.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install Supabase CLI
       uses: supabase/setup-cli@v1
       with:
-        version: 2.93.0
+        version: 2.95.4
 
     - name: Hard reset Supabase (clean state)
       run: |


### PR DESCRIPTION
## Summary

- Bumps Supabase CLI 2.93.0 -> 2.95.4 in integration stress test workflow
- Root cause: gotrue image tag incompatibility with CLI 2.93.0 caused supabase start to fail on GHA run 24977254742
- v2.95.4 is latest stable with updated image pins

## Test plan

- [ ] GHA Integration Stress Test passes on this branch
- [ ] supabase start step no longer fails with gotrue image pull error

🤖 Generated with [Claude Code](https://claude.com/claude-code)