### PR TITLE
fix(offerings): correct Pipeline Buildout price to canonical $4,997 [OCS-SN-SITE-REVAMP-0086]

### DIFF
--- a/apps/website/src/data/offerings.ts
+++ b/apps/website/src/data/offerings.ts
@@ -28,8 +28,8 @@ export const CONSULTING_SERVICES = [
   {
     id: 'pipeline-buildout',
     name: '21-Day Pipeline Buildout',
-    price: 2500,
-    priceLabel: 'From $2,500',
+    price: 4997,
+    priceLabel: '$4,997',
     period: 'one-time',
     timeline: '21 days',
     description:


### PR DESCRIPTION
## Summary

- Corrects `pipeline-buildout` price in `offerings.ts` from `From $2,500` → `$4,997`
- SN-OFFER-ARCH-001 v2.1.0 canonical: Pipeline Buildout is a **$4,997 project** (21-day delivery)
- The `From $2,500` price was never in the canonical document — source unknown, likely a draft figure

## Verification

- `SN-OFFER-ARCHITECTURE.md` §Tier 2: "Price: $4,997 (project)"
- Financial model confirms: "Pipeline Buildout: $4,997" under Revenue Architecture tree

## Test plan

- [ ] `/services` page shows $4,997 for 21-Day Pipeline Buildout (was showing "From $2,500")
- [ ] No other pricing changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)