### PR TITLE
feat(website): Business Systems Intake production path

### DIFF
--- a/apps/website/prisma/schema.prisma
+++ b/apps/website/prisma/schema.prisma
@@ -163,6 +163,7 @@ enum IntakeSource {
   PHASE_3
   LEAD_LEAK_CHECK
   RESOURCE_DOWNLOAD
+  BUSINESS_SYSTEMS
 }
 
 enum IntakeStatus {

--- a/apps/website/src/app/(marketing)/business-systems-intake/page.tsx
+++ b/apps/website/src/app/(marketing)/business-systems-intake/page.tsx
@@ -1,0 +1,88 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { BusinessSystemsIntakeForm } from '@/components/forms/BusinessSystemsIntakeForm';
+
+export const metadata: Metadata = {
+  title: 'Business Systems Intake | Strata Noble',
+  description:
+    'Tell us how work enters your business and where it stalls. We recommend a starting point: Audit, Fix, or Buildout.',
+  alternates: {
+    canonical: '/business-systems-intake',
+  },
+  openGraph: {
+    title: 'Business Systems Intake | Strata Noble',
+    description:
+      'Short intake for lead follow-up, CRM cleanup, customer tracking, and operating systems.',
+    url: '/business-systems-intake',
+  },
+};
+
+export default function BusinessSystemsIntakePage() {
+  return (
+    <main className="bg-white">
+      <section className="bg-command-navy text-white py-14 md:py-20">
+        <div className="container mx-auto px-4 max-w-3xl text-center">
+          <p className="text-sm uppercase tracking-wide text-field-sage mb-3">Strata Noble</p>
+          <h1 className="text-3xl md:text-5xl font-bold tracking-tight mb-4">
+            Business Systems Intake
+          </h1>
+          <p className="text-lg text-gray-300 max-w-2xl mx-auto leading-relaxed">
+            Tell me how work enters your business and where it stalls. This takes about 4 minutes. I
+            use it to recommend a starting point: Follow-Up Cleanup, Customer Tracker, CRM Rescue,
+            Workflow Map, Automation Readiness, or a simple Operations Dashboard. No passwords. No
+            tool logins.
+          </p>
+        </div>
+      </section>
+
+      <section className="container mx-auto px-4 py-12 md:py-16">
+        <div className="grid lg:grid-cols-[1fr_1.2fr] gap-10 max-w-5xl mx-auto">
+          <aside className="space-y-6 lg:pt-2">
+            <div>
+              <h2 className="text-xl font-semibold text-command-navy mb-2">What happens next</h2>
+              <ol className="list-decimal list-inside space-y-2 text-sm text-slate-grey">
+                <li>You submit this intake</li>
+                <li>I review fit and reply with Audit, Fix, Buildout, or no-fit</li>
+                <li>Optional 15-minute diagnostic if useful</li>
+              </ol>
+            </div>
+
+            <div>
+              <h2 className="text-xl font-semibold text-command-navy mb-2">Starting options</h2>
+              <ul className="space-y-3 text-sm text-slate-grey">
+                <li>
+                  <span className="font-medium text-command-navy">Business Systems Audit</span>
+                  {' '}$149 · 48 hours
+                </li>
+                <li>
+                  <span className="font-medium text-command-navy">48-Hour Operations Fix</span>
+                  {' '}$1,250 · one broken loop
+                </li>
+                <li>
+                  <span className="font-medium text-command-navy">Service System Buildout</span>
+                  {' '}$3,500 · about 14 days
+                </li>
+              </ul>
+            </div>
+
+            <p className="text-sm text-slate-grey">
+              Prefer email first?{' '}
+              <Link href="/contact?service=business-systems-audit" className="text-forest-green underline">
+                Contact with audit intent
+              </Link>
+              .
+            </p>
+          </aside>
+
+          <div id="form" className="bg-card border border-slate-grey/20 rounded-xl p-6 shadow-sm">
+            <h2 className="text-xl font-semibold text-command-navy mb-1">Start here</h2>
+            <p className="text-sm text-muted-foreground mb-5">
+              Required fields are marked. Optional fields stay optional.
+            </p>
+            <BusinessSystemsIntakeForm />
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/website/src/app/(marketing)/contact/page.tsx
+++ b/apps/website/src/app/(marketing)/contact/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+﻿import type { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
@@ -100,6 +100,14 @@ const SERVICE_INTENT: Record<string, { label: string; nextStep: string }> = {
     label: 'Process Improvement Sprint',
     nextStep: 'Tell us which single process is broken. We will confirm scope for the 10-day sprint.',
   },
+  'business-systems-audit': {
+    label: 'Business Systems Audit',
+    nextStep: 'Use the Business Systems Intake to start. We recommend Audit, Fix, or Buildout from there.',
+  },
+  'business-systems-intake': {
+    label: 'Business Systems Intake',
+    nextStep: 'Complete the intake so we can recommend the right starting engagement.',
+  },
 };
 
 function ContactPageContent({
@@ -148,7 +156,7 @@ function ContactPageContent({
               >
                 <h3 className="text-lg font-semibold text-command-navy mb-2">{path.title}</h3>
                 <p className="text-sm text-muted-foreground leading-relaxed">{path.description}</p>
-                <span className="inline-block mt-4 text-sm font-semibold text-primary">Continue →</span>
+                <span className="inline-block mt-4 text-sm font-semibold text-primary">Continue â†’</span>
               </Link>
             ))}
           </div>
@@ -195,3 +203,4 @@ function ContactPageContent({
     </main>
   );
 }
+

--- a/apps/website/src/app/api/intake/business-systems/route.ts
+++ b/apps/website/src/app/api/intake/business-systems/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import crypto from 'crypto';
+import { prisma } from '@/lib/prisma';
+import { rateLimit, createRateLimitHeaders } from '@/lib/rate-limit-buckets';
+import { notifyNewIntake } from '@/lib/ses-notify';
+import { sanitizeText, sanitizeEmail, sanitizeName } from '@/lib/sanitize';
+
+const businessSystemsSchema = z.object({
+  name: z.string().min(1).max(100),
+  businessName: z.string().min(1).max(200),
+  email: z.string().email(),
+  phoneOrLinkedIn: z.string().max(300).optional(),
+  whatYouSell: z.string().min(1).max(300),
+  revenueRange: z
+    .enum(['under-10k', '10k-40k', '40k-100k', '100k-plus', 'prefer-not', ''])
+    .optional(),
+  leadChannels: z
+    .array(
+      z.enum(['text', 'dm', 'email', 'phone', 'form', 'walk-in', 'referral', 'other'])
+    )
+    .min(1),
+  currentTracker: z.enum(['none', 'notes', 'spreadsheet', 'crm', 'notion-airtable', 'mix']),
+  loudestProblem: z.enum([
+    'missed-follow-up',
+    'no-tracker',
+    'crm-mess',
+    'unclear-workflow',
+    'automation-fuzzy',
+    'ops-dashboard',
+    'not-sure',
+  ]),
+  firstResponseOwner: z.enum(['me-only', 'me-and-team', 'no-owner']),
+  openLeadsAware: z.enum(['0-5', '6-20', '21-plus', 'unknown']),
+  winIn30Days: z.string().min(1).max(1000),
+  timeline: z.enum(['this-week', 'next-2-weeks', 'this-month', 'exploring']),
+  budgetComfort: z.enum(['under-250', '250-1500', '1500-5000', 'not-sure', '']).optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+function generateIdempotencyKey(email: string, source: string): string {
+  const dateBucket = new Date().toISOString().slice(0, 16);
+  return crypto.createHash('sha256').update(`${email}:${source}:${dateBucket}`).digest('hex');
+}
+
+function hashIP(request: NextRequest): string | null {
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    null;
+  if (!ip) return null;
+  return crypto.createHash('sha256').update(ip).digest('hex').slice(0, 16);
+}
+
+function scoreFit(payload: z.infer<typeof businessSystemsSchema>): 'good_fit' | 'maybe' | 'not_a_fit' {
+  const marketingOnly =
+    payload.loudestProblem === 'not-sure' &&
+    payload.timeline === 'exploring' &&
+    !payload.whatYouSell.trim();
+
+  if (marketingOnly || !payload.whatYouSell.trim()) {
+    return 'not_a_fit';
+  }
+
+  const systemPain = [
+    'missed-follow-up',
+    'no-tracker',
+    'crm-mess',
+    'unclear-workflow',
+    'automation-fuzzy',
+    'ops-dashboard',
+  ].includes(payload.loudestProblem);
+
+  const activeTimeline = ['this-week', 'next-2-weeks', 'this-month'].includes(payload.timeline);
+
+  if (systemPain && activeTimeline) return 'good_fit';
+  if (systemPain || activeTimeline) return 'maybe';
+  return 'maybe';
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const rateLimitResult = await rateLimit('intake', request);
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { error: 'Too many submissions. Try again in a minute.' },
+        { status: 429, headers: createRateLimitHeaders(rateLimitResult) }
+      );
+    }
+
+    const body = await request.json();
+    const validated = businessSystemsSchema.parse(body);
+
+    const sanitized = {
+      name: sanitizeName(validated.name),
+      email: sanitizeEmail(validated.email),
+      businessName: sanitizeText(validated.businessName, 200),
+      phoneOrLinkedIn: sanitizeText(validated.phoneOrLinkedIn || '', 300),
+      whatYouSell: sanitizeText(validated.whatYouSell, 300),
+      revenueRange: validated.revenueRange || '',
+      leadChannels: validated.leadChannels,
+      currentTracker: validated.currentTracker,
+      loudestProblem: validated.loudestProblem,
+      firstResponseOwner: validated.firstResponseOwner,
+      openLeadsAware: validated.openLeadsAware,
+      winIn30Days: sanitizeText(validated.winIn30Days, 1000),
+      timeline: validated.timeline,
+      budgetComfort: validated.budgetComfort || '',
+      notes: sanitizeText(validated.notes || '', 2000),
+      fitScore: scoreFit(validated),
+      form: 'business-systems-intake',
+    };
+
+    const idempotencyKey = generateIdempotencyKey(sanitized.email, 'BUSINESS_SYSTEMS');
+
+    const result = await prisma.$transaction(async (tx) => {
+      const existing = await tx.leadIntake.findUnique({
+        where: { idempotencyKey },
+      });
+
+      if (existing) {
+        return { duplicate: true, id: existing.id };
+      }
+
+      const intake = await tx.leadIntake.create({
+        data: {
+          source: 'BUSINESS_SYSTEMS',
+          name: sanitized.name,
+          email: sanitized.email,
+          businessName: sanitized.businessName,
+          payload: sanitized,
+          status: 'NEW',
+          ipHash: hashIP(request),
+          userAgent: request.headers.get('user-agent')?.slice(0, 500) || null,
+          idempotencyKey,
+        },
+      });
+
+      return { duplicate: false, id: intake.id };
+    });
+
+    if (!result.duplicate) {
+      try {
+        await notifyNewIntake({
+          source: 'BUSINESS_SYSTEMS',
+          name: sanitized.name,
+          email: sanitized.email,
+          businessName: sanitized.businessName,
+          payload: sanitized,
+        });
+      } catch (error) {
+        console.error('[Business Systems Intake] SES notification failed:', error);
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      id: result.id,
+      duplicate: result.duplicate,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    console.error('[Business Systems Intake] error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/website/src/components/forms/BusinessSystemsIntakeForm.tsx
+++ b/apps/website/src/components/forms/BusinessSystemsIntakeForm.tsx
@@ -1,0 +1,474 @@
+'use client';
+
+import { useState } from 'react';
+
+const leadChannelOptions = [
+  { value: 'text', label: 'Text' },
+  { value: 'dm', label: 'DM (Instagram / Facebook / etc.)' },
+  { value: 'email', label: 'Email' },
+  { value: 'phone', label: 'Phone' },
+  { value: 'form', label: 'Website form' },
+  { value: 'walk-in', label: 'Walk-in' },
+  { value: 'referral', label: 'Referral' },
+  { value: 'other', label: 'Other' },
+];
+
+const trackerOptions = [
+  { value: 'none', label: 'None' },
+  { value: 'notes', label: 'Notes app' },
+  { value: 'spreadsheet', label: 'Spreadsheet' },
+  { value: 'crm', label: 'HubSpot or other CRM' },
+  { value: 'notion-airtable', label: 'Notion / Airtable' },
+  { value: 'mix', label: 'Mix of tools' },
+];
+
+const loudestProblemOptions = [
+  { value: 'missed-follow-up', label: 'Missed follow-up' },
+  { value: 'no-tracker', label: 'No customer tracker' },
+  { value: 'crm-mess', label: 'CRM is a mess' },
+  { value: 'unclear-workflow', label: 'Unclear workflow' },
+  { value: 'automation-fuzzy', label: 'Want automation but process is fuzzy' },
+  { value: 'ops-dashboard', label: 'Need a simple ops dashboard' },
+  { value: 'not-sure', label: 'Not sure' },
+];
+
+const firstResponseOptions = [
+  { value: 'me-only', label: 'Me only' },
+  { value: 'me-and-team', label: 'Me + team' },
+  { value: 'no-owner', label: 'No clear owner' },
+];
+
+const openLeadsOptions = [
+  { value: '0-5', label: '0-5' },
+  { value: '6-20', label: '6-20' },
+  { value: '21-plus', label: '21+' },
+  { value: 'unknown', label: 'I honestly do not know' },
+];
+
+const timelineOptions = [
+  { value: 'this-week', label: 'This week' },
+  { value: 'next-2-weeks', label: 'Next 2 weeks' },
+  { value: 'this-month', label: 'This month' },
+  { value: 'exploring', label: 'Just exploring' },
+];
+
+const budgetOptions = [
+  { value: 'under-250', label: 'Under $250' },
+  { value: '250-1500', label: '$250-$1,500' },
+  { value: '1500-5000', label: '$1,500-$5,000' },
+  { value: 'not-sure', label: 'Not sure yet' },
+];
+
+const revenueOptions = [
+  { value: 'under-10k', label: 'Under $10k / month' },
+  { value: '10k-40k', label: '$10k-$40k / month' },
+  { value: '40k-100k', label: '$40k-$100k / month' },
+  { value: '100k-plus', label: '$100k+ / month' },
+  { value: 'prefer-not', label: 'Prefer not to say' },
+];
+
+type FormState = {
+  name: string;
+  businessName: string;
+  email: string;
+  phoneOrLinkedIn: string;
+  whatYouSell: string;
+  revenueRange: string;
+  leadChannels: string[];
+  currentTracker: string;
+  loudestProblem: string;
+  firstResponseOwner: string;
+  openLeadsAware: string;
+  winIn30Days: string;
+  timeline: string;
+  budgetComfort: string;
+  notes: string;
+};
+
+const emptyForm: FormState = {
+  name: '',
+  businessName: '',
+  email: '',
+  phoneOrLinkedIn: '',
+  whatYouSell: '',
+  revenueRange: '',
+  leadChannels: [],
+  currentTracker: '',
+  loudestProblem: '',
+  firstResponseOwner: '',
+  openLeadsAware: '',
+  winIn30Days: '',
+  timeline: '',
+  budgetComfort: '',
+  notes: '',
+};
+
+const fieldClass =
+  'w-full px-3 py-2 border border-slate-grey/30 rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-forest-green';
+
+export function BusinessSystemsIntakeForm() {
+  const [formData, setFormData] = useState<FormState>(emptyForm);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleChannelToggle = (value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      leadChannels: prev.leadChannels.includes(value)
+        ? prev.leadChannels.filter((c) => c !== value)
+        : [...prev.leadChannels, value],
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('loading');
+    setErrorMessage('');
+
+    if (formData.leadChannels.length === 0) {
+      setStatus('error');
+      setErrorMessage('Select at least one lead channel.');
+      return;
+    }
+
+    try {
+      const res = await fetch('/api/intake/business-systems', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || 'Submission failed');
+      }
+
+      setStatus('success');
+      setFormData(emptyForm);
+
+      if (typeof window !== 'undefined' && (window as Window & { gtag?: (...args: unknown[]) => void }).gtag) {
+        (window as Window & { gtag?: (...args: unknown[]) => void }).gtag?.(
+          'event',
+          'form_submit_success_business_systems'
+        );
+      }
+    } catch (error) {
+      setStatus('error');
+      setErrorMessage(error instanceof Error ? error.message : 'Something went wrong');
+    }
+  };
+
+  if (status === 'success') {
+    return (
+      <div className="bg-forest-green/10 border border-forest-green/30 rounded-lg p-6 text-center">
+        <div className="text-3xl mb-3 text-forest-green" aria-hidden>
+          ✓
+        </div>
+        <h3 className="text-xl font-semibold text-command-navy mb-2">Thanks. I got your intake.</h3>
+        <p className="text-sm text-slate-grey leading-relaxed">
+          I will review how work enters and where it stalls, then reply with a recommended starting
+          point (Audit, Fix, or Buildout) or a no-fit note. If urgent, reply to the confirmation
+          email with ASAP and your loudest problem in one sentence.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <div>
+        <label htmlFor="bsi-name" className="block text-sm font-medium mb-1">
+          Full name <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="bsi-name"
+          type="text"
+          required
+          maxLength={100}
+          value={formData.name}
+          onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="bsi-business" className="block text-sm font-medium mb-1">
+          Business name <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="bsi-business"
+          type="text"
+          required
+          maxLength={200}
+          value={formData.businessName}
+          onChange={(e) => setFormData({ ...formData, businessName: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="bsi-email" className="block text-sm font-medium mb-1">
+          Best email <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="bsi-email"
+          type="email"
+          required
+          value={formData.email}
+          onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="bsi-contact" className="block text-sm font-medium mb-1">
+          Best phone or LinkedIn URL
+        </label>
+        <input
+          id="bsi-contact"
+          type="text"
+          maxLength={300}
+          value={formData.phoneOrLinkedIn}
+          onChange={(e) => setFormData({ ...formData, phoneOrLinkedIn: e.target.value })}
+          className={fieldClass}
+          placeholder="Optional"
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="bsi-sell" className="block text-sm font-medium mb-1">
+          What do you sell / deliver? <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="bsi-sell"
+          type="text"
+          required
+          maxLength={300}
+          value={formData.whatYouSell}
+          onChange={(e) => setFormData({ ...formData, whatYouSell: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="bsi-revenue" className="block text-sm font-medium mb-1">
+          Rough monthly revenue range
+        </label>
+        <select
+          id="bsi-revenue"
+          value={formData.revenueRange}
+          onChange={(e) => setFormData({ ...formData, revenueRange: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        >
+          <option value="">Optional</option>
+          {revenueOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <fieldset>
+        <legend className="block text-sm font-medium mb-2">
+          Where do most new leads arrive? <span className="text-red-500">*</span>
+        </legend>
+        <div className="grid sm:grid-cols-2 gap-2">
+          {leadChannelOptions.map((o) => (
+            <label key={o.value} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={formData.leadChannels.includes(o.value)}
+                onChange={() => handleChannelToggle(o.value)}
+                className="w-4 h-4 rounded border-slate-grey/30 text-forest-green focus:ring-forest-green"
+                disabled={status === 'loading'}
+              />
+              {o.label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <div>
+        <label htmlFor="bsi-tracker" className="block text-sm font-medium mb-1">
+          What is your current tracker (if any)? <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="bsi-tracker"
+          required
+          value={formData.currentTracker}
+          onChange={(e) => setFormData({ ...formData, currentTracker: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        >
+          <option value="">Select one...</option>
+          {trackerOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="bsi-problem" className="block text-sm font-medium mb-1">
+          Which problem is loudest right now? <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="bsi-problem"
+          required
+          value={formData.loudestProblem}
+          onChange={(e) => setFormData({ ...formData, loudestProblem: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        >
+          <option value="">Select one...</option>
+          {loudestProblemOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="bsi-owner" className="block text-sm font-medium mb-1">
+          Who owns first response today? <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="bsi-owner"
+          required
+          value={formData.firstResponseOwner}
+          onChange={(e) => setFormData({ ...formData, firstResponseOwner: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        >
+          <option value="">Select one...</option>
+          {firstResponseOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="bsi-open" className="block text-sm font-medium mb-1">
+          How many open leads/quotes are you aware of right now?{' '}
+          <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="bsi-open"
+          required
+          value={formData.openLeadsAware}
+          onChange={(e) => setFormData({ ...formData, openLeadsAware: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        >
+          <option value="">Select one...</option>
+          {openLeadsOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="bsi-win" className="block text-sm font-medium mb-1">
+          What does a win look like in 30 days? <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          id="bsi-win"
+          required
+          maxLength={1000}
+          rows={3}
+          value={formData.winIn30Days}
+          onChange={(e) => setFormData({ ...formData, winIn30Days: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="bsi-timeline" className="block text-sm font-medium mb-1">
+          Timeline to start <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="bsi-timeline"
+          required
+          value={formData.timeline}
+          onChange={(e) => setFormData({ ...formData, timeline: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        >
+          <option value="">Select one...</option>
+          {timelineOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="bsi-budget" className="block text-sm font-medium mb-1">
+          Budget comfort for a starting engagement
+        </label>
+        <select
+          id="bsi-budget"
+          value={formData.budgetComfort}
+          onChange={(e) => setFormData({ ...formData, budgetComfort: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        >
+          <option value="">Optional</option>
+          {budgetOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="bsi-notes" className="block text-sm font-medium mb-1">
+          Anything else I should know?
+        </label>
+        <textarea
+          id="bsi-notes"
+          maxLength={2000}
+          rows={3}
+          value={formData.notes}
+          onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+          className={fieldClass}
+          disabled={status === 'loading'}
+        />
+      </div>
+
+      {status === 'error' && (
+        <div className="bg-red-50 border border-red-200 rounded-md p-3 text-sm text-red-700">
+          {errorMessage || 'Something went wrong. Please try again.'}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'loading' || formData.leadChannels.length === 0}
+        className="w-full bg-forest-green text-white px-6 py-3 rounded-md font-semibold hover:bg-forest-green/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {status === 'loading' ? 'Submitting...' : 'Submit Business Systems Intake'}
+      </button>
+
+      <p className="text-xs text-muted-foreground text-center">
+        About 4 minutes. No passwords. No tool logins.
+      </p>
+    </form>
+  );
+}

--- a/apps/website/src/data/offerings.ts
+++ b/apps/website/src/data/offerings.ts
@@ -13,7 +13,7 @@ export const ENTRY_PRODUCTS = [
     priceLabel: 'From $50',
     period: 'one-time',
     description:
-      'A clean, pre-configured Google Sheets tracker built for your business. Track jobs, clients, revenue, or the metrics that matter most — set up and ready to use.',
+      'A clean, pre-configured Google Sheets tracker built for your business. Track jobs, clients, revenue, or the metrics that matter most. Set up and ready to use.',
     deliverables: [
       'Custom-built Google Sheets tracker',
       'Setup and configuration',
@@ -61,7 +61,7 @@ export const ENTRY_PRODUCTS = [
     priceLabel: 'From $99',
     period: 'one-time',
     description:
-      'Install a simple, working follow-up system so no lead or client falls through the cracks. Templates, triggers, and a repeatable process — delivered and ready to use.',
+      'Install a simple, working follow-up system so no lead or client falls through the cracks. Templates, triggers, and a repeatable process. Delivered and ready to use.',
     deliverables: [
       'Follow-up sequence (3–5 touchpoints)',
       'Message templates',
@@ -77,7 +77,7 @@ export const ENTRY_PRODUCTS = [
     priceLabel: 'From $199',
     period: 'one-time',
     description:
-      'The essential operational foundation for a small service business. Intake process, follow-up system, service menu, and a simple tracker — organized and ready to run.',
+      'The essential operational foundation for a small service business. Intake process, follow-up system, service menu, and a simple tracker. Organized and ready to run.',
     deliverables: [
       'Intake process setup',
       'Follow-up sequence',
@@ -100,14 +100,14 @@ export const ASSESSMENTS = [
     period: 'one-time',
     timeline: '48 hours',
     description:
-      "A focused review of your current business systems and processes. Identify what's working, what's broken, and what to fix first — delivered in 48 hours.",
+      "A focused review of your current business systems and processes. Identify what's working, what's broken, and what to fix first. Delivered in 48 hours.",
     deliverables: [
       'Systems review report',
       'Prioritized fix list',
       'Recommended next steps',
     ],
     cta: 'Book an Audit',
-    ctaLink: '/contact?service=business-systems-audit',
+    ctaLink: '/business-systems-intake',
   },
   {
     id: 'small-business-checkup',
@@ -117,7 +117,7 @@ export const ASSESSMENTS = [
     period: 'one-time',
     timeline: '3–5 business days',
     description:
-      'A practical operational review for service businesses. Covers intake, follow-up systems, service delivery, and reporting — you get a clear picture of where things stand and a prioritized fix list.',
+      'A practical operational review for service businesses. Covers intake, follow-up systems, service delivery, and reporting. You get a clear picture of where things stand and a prioritized fix list.',
     deliverables: [
       'Operational review report',
       'Gap analysis',
@@ -140,7 +140,7 @@ export const CONSULTING_SERVICES = [
     timeline: '48–72 hours',
     entryPoint: 'Free 30-minute diagnostic call',
     description:
-      "Audit the business's current operational infrastructure — how work flows, where it breaks, what's missing, what's redundant. Identify the top 3–5 structural issues and deliver a prioritized action plan.",
+      "Audit the business's current operational infrastructure. How work flows, where it breaks, what's missing, what's redundant. Identify the top 3–5 structural issues and deliver a prioritized action plan.",
     deliverables: [
       'Systems audit report',
       'Prioritized fix list',
@@ -158,7 +158,7 @@ export const CONSULTING_SERVICES = [
     period: 'one-time',
     timeline: '48 hours',
     description:
-      'A fast fix for one broken business process. Identify the failure point, redesign the flow, implement the fix, and verify it works — delivered in 48 hours.',
+      'A fast fix for one broken business process. Identify the failure point, redesign the flow, implement the fix, and verify it works. Delivered in 48 hours.',
     deliverables: [
       'Process diagnosis',
       'Redesigned and implemented fix',
@@ -194,7 +194,7 @@ export const CONSULTING_SERVICES = [
     period: 'one-time',
     timeline: '14 days',
     description:
-      'A practical system buildout for service businesses. Includes intake, scheduling, follow-up, and delivery infrastructure — installed and configured for how your business actually works.',
+      'A practical system buildout for service businesses. Includes intake, scheduling, follow-up, and delivery infrastructure. Installed and configured for how your business actually works.',
     deliverables: [
       'Intake system (installed)',
       'Scheduling and follow-up workflows',

--- a/apps/website/src/lib/ses-notify.ts
+++ b/apps/website/src/lib/ses-notify.ts
@@ -1,11 +1,27 @@
 import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
 
+// Match email.ts / mailer.ts production env conventions on Netlify.
+const AWS_REGION =
+  process.env.STRATANOBLE_AWS_REGION || process.env.AWS_REGION || 'us-east-1';
+const AWS_ACCESS_KEY_ID =
+  process.env.STRATANOBLE_AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID;
+const AWS_SECRET_ACCESS_KEY =
+  process.env.STRATANOBLE_AWS_SECRET_ACCESS_KEY ||
+  process.env.AWS_SECRET_ACCESS_KEY ||
+  process.env.AWS_SES_SECRET;
+const SES_FROM_EMAIL = process.env.SES_FROM_EMAIL;
+const NOTIFICATION_EMAIL =
+  process.env.NOTIFICATION_EMAIL || process.env.ADMIN_EMAIL;
+
 const sesClient = new SESClient({
-  region: process.env.AWS_REGION || 'us-east-1',
-  credentials: process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY ? {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  } : undefined,
+  region: AWS_REGION,
+  credentials:
+    AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY
+      ? {
+          accessKeyId: AWS_ACCESS_KEY_ID,
+          secretAccessKey: AWS_SECRET_ACCESS_KEY,
+        }
+      : undefined,
 });
 
 export interface IntakeNotification {
@@ -17,9 +33,13 @@ export interface IntakeNotification {
 }
 
 export async function notifyNewIntake(intake: IntakeNotification): Promise<void> {
-  // Skip if credentials not configured
-  if (!process.env.SES_FROM_EMAIL || !process.env.NOTIFICATION_EMAIL) {
+  if (!SES_FROM_EMAIL || !NOTIFICATION_EMAIL) {
     console.log('[SES] Notification skipped - credentials not configured');
+    return;
+  }
+
+  if (!AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY) {
+    console.log('[SES] Notification skipped - AWS credentials not configured');
     return;
   }
 
@@ -27,9 +47,9 @@ export async function notifyNewIntake(intake: IntakeNotification): Promise<void>
     const emailBody = formatIntakeEmail(intake);
 
     const command = new SendEmailCommand({
-      Source: process.env.SES_FROM_EMAIL,
+      Source: SES_FROM_EMAIL,
       Destination: {
-        ToAddresses: [process.env.NOTIFICATION_EMAIL],
+        ToAddresses: [NOTIFICATION_EMAIL],
       },
       Message: {
         Subject: {

--- a/apps/website/src/lib/supabase/server.ts
+++ b/apps/website/src/lib/supabase/server.ts
@@ -1,6 +1,4 @@
-'use server';
-
-import { createClient } from '@supabase/supabase-js';
+﻿import { createClient } from '@supabase/supabase-js';
 import { Database } from '@/types/database';
 
 /**
@@ -171,3 +169,4 @@ export function withAdminClient<TParams extends any[], TResult>(
     return handler(admin, ...params);
   };
 }
+

--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -183,6 +183,9 @@ export async function middleware(request: NextRequest) {
     '/about',
     '/achievery/auth',
     '/achievery-preview',
+    '/business-systems-intake',
+    '/systems-audit',
+    '/operations-buildout',
   ];
 
   const publicApiRoutes = [

--- a/supabase/migrations/0031_add_business_systems_intake_source.sql
+++ b/supabase/migrations/0031_add_business_systems_intake_source.sql
@@ -1,0 +1,4 @@
+-- Add BUSINESS_SYSTEMS to IntakeSource enum for Business Systems Intake form
+-- Migration: 0031_add_business_systems_intake_source.sql
+
+ALTER TYPE "IntakeSource" ADD VALUE IF NOT EXISTS 'BUSINESS_SYSTEMS';


### PR DESCRIPTION
## Summary
- Add `/business-systems-intake` page and `POST /api/intake/business-systems`
- Wire Business Systems Audit CTA to intake URL
- Add contact intent for `?service=business-systems-audit`
- Align SES notify with Netlify `STRATANOBLE_AWS_*` + `ADMIN_EMAIL`/`NOTIFICATION_EMAIL`
- Add Prisma/Supabase `BUSINESS_SYSTEMS` intake source

## Test plan
- [ ] `/business-systems-intake` returns 200 on production
- [ ] Contact intent banner shows for business-systems-audit
- [ ] Submit safe test intake; LeadIntake source BUSINESS_SYSTEMS
- [ ] SES notification delivered
